### PR TITLE
maint: allow installing without having deps

### DIFF
--- a/bda/version.py
+++ b/bda/version.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-import six
 import subprocess
 import json
 
@@ -25,8 +24,6 @@ def _get_git_output(args, capture_stderr=False):
 
     data = data.strip()
 
-    if six.PY2:
-        return data
     return data.decode("utf8")
 
 
@@ -36,7 +33,7 @@ def _get_gitinfo_file(git_file=None):
         git_file = os.path.join(bda_dir, "GIT_INFO")
 
     with open(git_file) as data_file:
-        data = [_unicode_to_str(x) for x in json.loads(data_file.read().strip())]
+        data = list(json.loads(data_file.read().strip()))
         git_origin = data[0]
         git_hash = data[1]
         git_description = data[2]
@@ -49,11 +46,6 @@ def _get_gitinfo_file(git_file=None):
         "git_branch": git_branch,
     }
 
-
-def _unicode_to_str(u):
-    if six.PY2:
-        return u.encode("utf8")
-    return u
 
 
 def construct_version_info():

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,10 @@ import glob
 import os
 import io
 import json
+import sys
 
-from bda import version
+sys.path.append("bda")
+import version
 
 data = [
     version.git_origin,


### PR DESCRIPTION
This allows installing the code without having the deps already installed. I'd recommend going all-in with setuptools_scm and pyproject.toml, but this will do for a start.